### PR TITLE
Fixtures for Users

### DIFF
--- a/rareapi/fixtures/user.json
+++ b/rareapi/fixtures/user.json
@@ -1,0 +1,62 @@
+[
+  {
+    "model": "rareapi.user",
+    "pk": 1,
+    "fields": {
+      "first_name" : "Johnny",
+      "last_name" : "Dime",
+      "bio" : "I like Cash",
+      "profile_image_url" : "https://headlinerhub.com/assets/image-cache/img/assets/img/cash.235fce1d.jpg",
+      "email" : "ring@mozmail.com",
+      "created" : "2000-10-19T20:30:15.123Z",
+      "active" : false,
+      "is_staff" : false,
+      "uid" : "fakeuid1"
+    }
+  },
+  {
+    "model": "rareapi.user",
+    "pk": 2,
+    "fields": {
+      "first_name" : "Jason",
+      "last_name" : "Cheetham",
+      "bio" : "You know this boogie is for reeeeeeal",
+      "profile_image_url" : "https://i.ebayimg.com/images/g/nUAAAOSwaxZm-7zI/s-l400.jpg",
+      "email" : "jamiroquai@gmail.com",
+      "created" : "2001-08-14T20:30:15.123Z",
+      "active" : true,
+      "is_staff" : true,
+      "uid" : "fakeuid2"
+    }
+  },
+  {
+    "model": "rareapi.user",
+    "pk": 3,
+    "fields": {
+      "first_name" : "Eric",
+      "last_name" : "Bishop",
+      "bio" : "I played Django, what do you mean the framework?!",
+      "profile_image_url" : "https://static.wikia.nocookie.net/rio/images/0/0b/Jamie_Foxx.jpg/revision/latest?cb=20180504203411",
+      "email" : "jamie@mozmail.com",
+      "created" : "2021-03-12T20:30:15.123Z",
+      "active" : true,
+      "is_staff" : true,
+      "uid" : "fakeuid3"
+    }
+  },
+  {
+    "model": "rareapi.user",
+    "pk": 4,
+    "fields": {
+      "first_name" : "Edgar",
+      "last_name" : "Poe",
+      "bio" : "DONT DELETE ME AHHHHHHHHH",
+      "profile_image_url" : "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQwX6rZ_VLwrOK9E86bK6C8RtHY1kFMWllc-Ca4Aux1mwu1j7A7",
+      "email" : "EAP@gmail.com",
+      "created" : "2007-08-14T20:30:15.123Z",
+      "active" : false,
+      "is_staff" : false,
+      "uid" : "fakeuid4"
+    }
+  }
+]


### PR DESCRIPTION
# Add User Test Fixtures

## Description

This pull request adds comprehensive test fixtures for the User model to support development and testing workflows. The fixtures include:

- Created `user.json` fixture file with 4 diverse user records
- Includes users with varying active/inactive states and staff permissions
- Supports both active and inactive user scenarios for comprehensive testing
- Includes staff and non-staff users for permission testing

The fixture data includes users representing different personas:
- Johnny Dime (inactive, non-staff user)
- Jason Cheetham (active, staff user) 
- Eric Bishop (active, staff user)
- Edgar Poe (inactive, non-staff user with humorous bio)

## Motivation and Context

This change is required to provide consistent test data for development and testing purposes. Without proper test fixtures, developers would need to manually create users for testing, leading to inconsistent data and slower development cycles.

## How Can This Be Tested?

- TBD

## Screenshots (if appropriate):

- TBD

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)