### PR TITLE
# Add UPDATE and DELETE operations for Category and Post models

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-django = "==4.1.3"
+django = "*"
 autopep8 = "==2.0.0"
 pylint = "==2.15.5"
 djangorestframework = "==3.14.0"

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-django = "*"
+django = "==4.1.3"
 autopep8 = "==2.0.0"
 pylint = "==2.15.5"
 djangorestframework = "==3.14.0"

--- a/rareapi/views/category.py
+++ b/rareapi/views/category.py
@@ -43,6 +43,26 @@ class CategoryView(ViewSet):
         serializer = CategorySerializer(category)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
     
+    def update(self, request, pk):
+        """Handle PUT requests for a genre
+
+        Returns:
+            Response -- Empty body with 204 status code
+        """
+
+        id = pk
+        category = Category.objects.get(pk=pk)
+        category.label = request.data["label"]
+
+        category.save()
+
+        serializer = CategorySerializer(category)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+    
+    def destroy(self, request, pk):
+        category = Category.objects.get(pk=pk)
+        category.delete()
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
     
     
 

--- a/rareapi/views/post.py
+++ b/rareapi/views/post.py
@@ -38,6 +38,30 @@ class PostView(ViewSet):
     )
     serializer = PostSerializer(post)
     return Response(serializer.data, status=status.HTTP_201_CREATED)
+  
+  def update(self, request, pk):
+    """Handle PUT requests for Posts"""
+   
+    post = Post.objects.get(pk=pk)
+    user = User.objects.get(pk=request.data["user"])
+    post.user=user
+    category = Category.objects.get(pk=request.data["categoryid"])
+    post.category=category
+    post.title=request.data["title"]
+    post.publication_date=request.data["publication_date"]
+    post.image_url=request.data["image_url"]
+    post.content=request.data["content"]
+    post.approved=request.data["approved"]
+    post.save()
+   
+    serializer = PostSerializer(post)
+    return Response(serializer.data, status=status.HTTP_200_OK)
+ 
+  def destroy(self, request, pk):
+    post = Post.objects.get(pk=pk)
+    post.delete()
+    return Response(None, status=status.HTTP_204_NO_CONTENT)
+   
 
 
 class PostSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
# Add UPDATE and DELETE operations for Category and Post models

## Description
Added complete CRUD functionality by implementing `update` and `destroy` methods for both Category and Post ViewSets. These methods enable full editing and deletion capabilities for categories and posts through the API.

**Changes made:**
- Added `update` method to CategoryViewSet for handling PUT requests to modify category labels
- Added `destroy` method to CategoryViewSet for handling DELETE requests to remove categories
- Added `update` method to PostViewSet for handling PUT requests to modify all post fields
- Added `destroy` method to PostViewSet for handling DELETE requests to remove posts

## Related Issue
<!-- Please link to the issue here -->

## Motivation and Context
This change completes the CRUD operations for the rare API, allowing users to fully manage categories and posts. Previously, users could only create and read these resources, but couldn't update existing entries or remove unwanted ones. This functionality is essential for a complete content management system.

## How Can This Be Tested?
**Testing Category operations:**
1. Send PUT request to `/categories/{id}` with JSON body containing `{"label": "Updated Category Name"}`
2. Verify category is updated with new label
3. Send DELETE request to `/categories/{id}`
4. Verify category is removed from database

**Testing Post operations:**
1. Send PUT request to `/posts/{id}` with complete post data including user, categoryid, title, publication_date, image_url, content, and approved fields
2. Verify all post fields are updated correctly
3. Send DELETE request to `/posts/{id}`
4. Verify post is removed from database


## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)